### PR TITLE
Remove softmax from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,12 @@ class MyModule(nn.Module):
         self.dropout = nn.Dropout(0.5)
         self.dense1 = nn.Linear(num_units, num_units)
         self.output = nn.Linear(num_units, 2)
-        self.softmax = nn.Softmax(dim=-1)
 
     def forward(self, X, **kwargs):
         X = self.nonlin(self.dense0(X))
         X = self.dropout(X)
         X = self.nonlin(self.dense1(X))
-        X = self.softmax(self.output(X))
+        X = self.output(X)
         return X
 
 net = RayTrainNeuralNet(
@@ -106,13 +105,12 @@ class MyModule(nn.Module):
         self.dropout = nn.Dropout(0.5)
         self.dense1 = nn.Linear(num_units, num_units)
         self.output = nn.Linear(num_units, 2)
-        self.softmax = nn.Softmax(dim=-1)
 
     def forward(self, X, **kwargs):
         X = self.nonlin(self.dense0(X))
         X = self.dropout(X)
         X = self.nonlin(self.dense1(X))
-        X = self.softmax(self.output(X))
+        X = self.output(X)
         return X
 
 net = RayTrainNeuralNet(

--- a/examples/readme_example.py
+++ b/examples/readme_example.py
@@ -37,13 +37,12 @@ if __name__ == "__main__":
             self.dropout = nn.Dropout(0.5)
             self.dense1 = nn.Linear(num_units, num_units)
             self.output = nn.Linear(num_units, 2)
-            self.softmax = nn.Softmax(dim=-1)
 
         def forward(self, X, **kwargs):
             X = self.nonlin(self.dense0(X))
             X = self.dropout(X)
             X = self.nonlin(self.dense1(X))
-            X = self.softmax(self.output(X))
+            X = self.output(X)
             return X
 
     net = RayTrainNeuralNet(


### PR DESCRIPTION
I don't think there should be a softmax in the output layer if you use `CrossEntropyLoss` since CrossEntropyLoss takes logits as inputs (and performs a `LogSoftmax` internally): https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html.